### PR TITLE
Add ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _site/
 # counterproductive to check this file into the repository.
 # Details at https://github.com/github/pages-gem/issues/768
 Gemfile.lock
+node_modules/


### PR DESCRIPTION
## Summary
- ignore `node_modules`
- add root `.eslintrc.json` so linting uses `eslint:recommended` in browser env

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685bcfd43f80832baa85f30460b7267b